### PR TITLE
fix spelling of targe to target

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A Flutter application designed to provide a user-friendly interface for selectin
     ```bash
     flutter build apk --release --target-platform android-arm64
 
-4. But if you want to build the app normally without targe platform run this command:
+4. But if you want to build the app normally without target platform run this command:
     ```bash
     flutter build apk
 --- end ---


### PR DESCRIPTION
fix spelling of targe to target

1. Check spelling of target.
2. Check if the instruction number 4 in the Build section about building app is now in correct spelling.
3. Check spelling of "targe" to "target'.