### PR TITLE
Remove estimated harvest in Corntype Detection Fix bugs

### DIFF
--- a/lib/pages/detectionPages/corn_type_stream.dart
+++ b/lib/pages/detectionPages/corn_type_stream.dart
@@ -226,7 +226,6 @@ ScaffoldMessenger.of(context).showSnackBar(
     }
 
     Map<String, int> labelCounts = getLabelCounts();
-    int estimatedHarvest = getTotalDetections();
 
     return Scaffold(
       body: Stack(
@@ -286,13 +285,6 @@ ScaffoldMessenger.of(context).showSnackBar(
                       style: const TextStyle(fontSize: 14),
                     )),
                 const SizedBox(height: 10),
-                Text(
-                  "Estimated Harvest: $estimatedHarvest",
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 16,
-                  ),
-                ),
               ],
             ),
           ),
@@ -438,11 +430,6 @@ class ModelReading2 {
   }
 
   // Safely calculate estimated harvest
-  int calculateEstimatedHarvest() {
-    final viableCount =
-        labelCounts['Viable'] ?? 0; // Default to 0 if 'Viable' is null
-    return viableCount * 4;
-  }
 }
 
 void main() async {

--- a/lib/pages/detectionPages/liveViabilityDetectionPage.dart
+++ b/lib/pages/detectionPages/liveViabilityDetectionPage.dart
@@ -174,7 +174,7 @@ class _YoloVideoState extends State<YoloVideo> with WidgetsBindingObserver {
             const Text("Detection results saved to history!"),
           ],
         ),
-        duration: const Duration(seconds: 3), // Adjust display duration
+        duration: const Duration(seconds: 2), // Adjust display duration
         backgroundColor: Colors.green, // Optional: change the background color
       ),
     );
@@ -287,7 +287,7 @@ class _YoloVideoState extends State<YoloVideo> with WidgetsBindingObserver {
                     )),
                 const SizedBox(height: 10),
                 Text(
-                  "Estimated Harvest: $estimatedHarvest",
+                  "Estimated Harvest: $estimatedHarvest pieces of corn",
                   style: const TextStyle(
                     fontWeight: FontWeight.bold,
                     fontSize: 16,


### PR DESCRIPTION
Remove estimated harvest in Corntype Detection Fix bugs

1. Check if the estimated harvest is removed in the corn type detections.
2. Check if the labels in the viability app is detailed.
3. Check loading snackbar animation will only last for 2 seconds.